### PR TITLE
feat: compact Telegram notifications toggle

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -510,7 +510,7 @@ async def send_telegram_notification(event: str, payload: dict[str, Any], force:
         event_title,
         message,
     ]
-    if details:
+    if details and not get_telegram_compact_notifications():
         lines.append("")
         for key, value in details.items():
             rendered = format_notification_detail_value(value)
@@ -762,6 +762,17 @@ def get_notification_message_templates() -> dict[str, str]:
 
 def set_notification_message_templates(templates: dict[str, str]) -> None:
     set_setting("notification_message_templates", json.dumps(templates, ensure_ascii=False))
+
+
+def get_telegram_compact_notifications() -> bool:
+    raw = (get_setting("telegram_compact_notifications") or "").strip().lower()
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return True
+
+
+def set_telegram_compact_notifications(enabled: bool) -> None:
+    set_setting("telegram_compact_notifications", "true" if enabled else "false")
 
 
 def render_notification_message(event: str, details: dict[str, Any] | None = None) -> str:
@@ -2051,6 +2062,7 @@ async def notification_messages_page(request: Request) -> HTMLResponse:
             "placeholders": NOTIFICATION_MESSAGE_PLACEHOLDERS,
             "global_placeholders": NOTIFICATION_MESSAGE_GLOBAL_PLACEHOLDERS,
             "saved": templates_data,
+            "telegram_compact": get_telegram_compact_notifications(),
             "demo_mode": DEMO_MODE,
         },
     )
@@ -2068,7 +2080,13 @@ async def notification_messages_action(request: Request) -> HTMLResponse:
             if value and value != DEFAULT_NOTIFICATION_MESSAGES[event]:
                 new_templates[event] = value
         set_notification_message_templates(new_templates)
-        logger.info("Notification message templates updated (%s custom).", len(new_templates))
+        compact_flag = form.get("telegram_compact") == "on"
+        set_telegram_compact_notifications(compact_flag)
+        logger.info(
+            "Notification message templates updated (%s custom, telegram_compact=%s).",
+            len(new_templates),
+            compact_flag,
+        )
         return RedirectResponse(url="/notifications/messages?saved=1", status_code=303)
     except Exception:
         logger.exception("Unexpected error saving notification message templates.")

--- a/app/templates/notification_messages.html
+++ b/app/templates/notification_messages.html
@@ -86,18 +86,15 @@
         <form method="post" action="/notifications/messages" class="stack top-gap" id="notification-messages-form">
 
           <div class="notification-msg-block">
-            <div style="display: flex; align-items: center; gap: 0.6rem;">
+            <label class="checkbox-row">
               <input
                 type="checkbox"
                 name="telegram_compact"
-                id="telegram_compact"
                 {% if telegram_compact %}checked{% endif %}
               >
-              <label for="telegram_compact" style="display: inline; margin: 0; cursor: pointer; font-weight: 600;">
-                Compact Telegram notifications
-              </label>
-            </div>
-            <p class="hint" style="margin-top: 0.4rem;">
+              <span>Compact Telegram notifications</span>
+            </label>
+            <p class="hint">
               When enabled (default), Telegram messages contain only the title and the rendered message.
               Disable to also append the structured <code>key: value</code> details block (trigger,
               account_id, tunnel counts, skipped tunnels, etc.). The webhook channel is unaffected and

--- a/app/templates/notification_messages.html
+++ b/app/templates/notification_messages.html
@@ -85,6 +85,24 @@
 
         <form method="post" action="/notifications/messages" class="stack top-gap" id="notification-messages-form">
 
+          <div class="notification-msg-block">
+            <label for="telegram_compact" style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer;">
+              <input
+                type="checkbox"
+                name="telegram_compact"
+                id="telegram_compact"
+                {% if telegram_compact %}checked{% endif %}
+              >
+              <span class="notification-event-label">Compact Telegram notifications</span>
+            </label>
+            <p class="hint">
+              When enabled (default), Telegram messages contain only the title and the rendered message.
+              Disable to also append the structured <code>key: value</code> details block (trigger,
+              account_id, tunnel counts, skipped tunnels, etc.). The webhook channel is unaffected and
+              always receives the full payload.
+            </p>
+          </div>
+
           {% for event in events %}
           {% set current = saved.get(event, "") %}
           {% set default_msg = defaults[event] %}

--- a/app/templates/notification_messages.html
+++ b/app/templates/notification_messages.html
@@ -85,7 +85,7 @@
 
         <form method="post" action="/notifications/messages" class="stack top-gap" id="notification-messages-form">
 
-          <div class="notification-msg-block">
+          <section class="notice">
             <label class="checkbox-row">
               <input
                 type="checkbox"
@@ -94,13 +94,13 @@
               >
               <span>Compact Telegram notifications</span>
             </label>
-            <p class="hint">
-              When enabled (default), Telegram messages contain only the title and the rendered message.
-              Disable to also append the structured <code>key: value</code> details block (trigger,
-              account_id, tunnel counts, skipped tunnels, etc.). The webhook channel is unaffected and
-              always receives the full payload.
+            <p class="hint" style="margin: 0.6rem 0 0;">
+              When enabled (default), Telegram messages contain only the title and the rendered
+              message. Disable to also append the structured <code>key: value</code> details block
+              (trigger, account_id, tunnel counts, skipped tunnels, etc.). The webhook channel is
+              unaffected and always receives the full payload.
             </p>
-          </div>
+          </section>
 
           {% for event in events %}
           {% set current = saved.get(event, "") %}

--- a/app/templates/notification_messages.html
+++ b/app/templates/notification_messages.html
@@ -86,16 +86,18 @@
         <form method="post" action="/notifications/messages" class="stack top-gap" id="notification-messages-form">
 
           <div class="notification-msg-block">
-            <label for="telegram_compact" style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer;">
+            <div style="display: flex; align-items: center; gap: 0.6rem;">
               <input
                 type="checkbox"
                 name="telegram_compact"
                 id="telegram_compact"
                 {% if telegram_compact %}checked{% endif %}
               >
-              <span class="notification-event-label">Compact Telegram notifications</span>
-            </label>
-            <p class="hint">
+              <label for="telegram_compact" style="display: inline; margin: 0; cursor: pointer; font-weight: 600;">
+                Compact Telegram notifications
+              </label>
+            </div>
+            <p class="hint" style="margin-top: 0.4rem;">
               When enabled (default), Telegram messages contain only the title and the rendered message.
               Disable to also append the structured <code>key: value</code> details block (trigger,
               account_id, tunnel counts, skipped tunnels, etc.). The webhook channel is unaffected and


### PR DESCRIPTION
## Summary
- Adds a per-instance setting that suppresses the structured `key: value` details block in Telegram messages, leaving only title and rendered message.
- Exposed as a checkbox at the top of `/notifications/messages`, checked by default — Telegram notifications are compact out of the box.
- The webhook channel is unaffected and continues to receive the full payload.

## Why
Automatic backup notifications on Telegram had grown noisy (trigger, account_id, tunnel_count, skipped_tunnels, …). Most users only need the one-liner; the structured details remain available for webhook consumers.

## Test plan
- [x] Build the image and run a manual `notification_test` — Telegram message should contain only the title and message line.
- [x] Trigger an automatic backup — confirm the Telegram notification matches the compact format.
- [ ] Uncheck "Compact Telegram notifications" on `/notifications/messages`, save, repeat — verify the verbose `key: value` block is appended again.
- [ ] Confirm the webhook payload still includes the full `details` object regardless of the toggle.